### PR TITLE
Implement Ollama fallback and fix data parsing

### DIFF
--- a/codes/app.py
+++ b/codes/app.py
@@ -89,14 +89,16 @@ if user_prompt:
     st.chat_message("user").markdown(user_prompt)
 
     # 2. Parse intent ➜ date range
-    from nlp import parse_request            # implemented in Part 2
+    from nlp import parse_request, chat_with_ollama
     parsed = parse_request(user_prompt)
 
     if parsed:
         start_d, end_d = parsed["start"], parsed["end"]
     else:
-        end_d   = date.today()
-        start_d = end_d - timedelta(days=6)  # default last 7 days
+        reply = chat_with_ollama(user_prompt)
+        st.session_state.history.append(("assistant", reply))
+        st.chat_message("assistant").markdown(reply)
+        st.stop()
 
     # 3. Fetch scores
     from data_source import get_scores       # implemented in Part 2

--- a/codes/data_source.py
+++ b/codes/data_source.py
@@ -23,5 +23,5 @@ def get_scores(start: date, end: date) -> dict:
     df = _df()
     mask = (df["Date"] >= start) & (df["Date"] <= end)
     seg = df.loc[mask].sort_values("Date")
-    labels = seg["Date"].dt.strftime("%a %-d")
+    labels = seg["Date"].apply(lambda d: d.strftime("%a %-d"))
     return dict(zip(labels, seg["Score"].astype(int)))

--- a/codes/nlp.py
+++ b/codes/nlp.py
@@ -1,6 +1,8 @@
-"""
-Robust date-range extractor for the Advisor chatbot.
-Public function   parse_request(user_text) -> {"start": date, "end": date} | None
+"""Robust date-range extractor for the Advisor chatbot.
+
+Public function::
+
+    parse_request(user_text) -> {"start": date, "end": date} | None
 """
 
 import re, json, requests
@@ -127,6 +129,27 @@ def _llama_parse(txt: str):
         return date.fromisoformat(obj["start"]), date.fromisoformat(obj["end"])
     except Exception:
         return None
+
+def chat_with_ollama(user_text: str) -> str:
+    """Return a helpful response from the Llama model."""
+    pl = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a friendly assistant helping users with their "
+                    "Food Score queries."
+                ),
+            },
+            {"role": "user", "content": user_text},
+        ],
+    }
+    try:
+        r = requests.post(OLLAMA_URL, json=pl, timeout=20).json()
+        return r.get("message", {}).get("content", "")
+    except Exception:
+        return "Sorry, I couldn't understand your request."
 
 # ───────────────────────── public API ─────────────────────────
 def parse_request(user_text: str):


### PR DESCRIPTION
## Summary
- fix date label conversion bug in `get_scores`
- document NLP parser and add new `chat_with_ollama` helper
- use Ollama chat as fallback in app when NLP parsing fails

## Testing
- `python -m py_compile main.py codes/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852910fc19483299ad8d2d49a8f06ac