### PR TITLE
Fix CSV error handling

### DIFF
--- a/codes/app.py
+++ b/codes/app.py
@@ -5,7 +5,6 @@ Other modules (`nlp.py`, `data_source.py`, `charts.py`) are imported
 but may be stubs until Parts 2-4 are added.
 """
 
-from datetime import date, timedelta
 import streamlit as st
 
 # ───────────────────────── Page & CSS ──────────────────────────

--- a/codes/charts.py
+++ b/codes/charts.py
@@ -13,7 +13,9 @@ build_chart(scores: dict[str, int]) -> str
 """
 
 from __future__ import annotations
-import json, pathlib, uuid
+import json
+import pathlib
+import uuid
 
 __all__ = ["build_chart"]
 

--- a/codes/data_source.py
+++ b/codes/data_source.py
@@ -3,7 +3,8 @@ In-memory CSV store.
 Expected columns: Date, Score
 """
 
-import pandas as pd, io
+import pandas as pd
+import io
 from functools import lru_cache
 from datetime import date
 
@@ -20,7 +21,10 @@ def store_csv(raw: bytes):
     _df.__wrapped__ = lambda: df  # replace cached function
 
 def get_scores(start: date, end: date) -> dict:
-    df = _df()
+    try:
+        df = _df()
+    except RuntimeError:
+        return {}
     mask = (df["Date"] >= start) & (df["Date"] <= end)
     seg = df.loc[mask].sort_values("Date")
     labels = seg["Date"].apply(lambda d: d.strftime("%a %-d"))

--- a/codes/nlp.py
+++ b/codes/nlp.py
@@ -5,7 +5,9 @@ Public function::
     parse_request(user_text) -> {"start": date, "end": date} | None
 """
 
-import re, json, requests
+import re
+import json
+import requests
 from datetime import date, timedelta
 import dateparser
 


### PR DESCRIPTION
## Summary
- fix CSV not loaded crash by catching the exception in `get_scores`
- clean up unused imports and split multi-imports
- run ruff to apply formatting fixes

## Testing
- `ruff check .`
- `python -m py_compile codes/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685293518bd48329bd2995e65fe224f8