### PR TITLE
Add support for numeric day values in CSV

### DIFF
--- a/codes/data_source.py
+++ b/codes/data_source.py
@@ -16,7 +16,12 @@ def _df():
 
 def store_csv(raw: bytes):
     df = pd.read_csv(io.BytesIO(raw))
-    df["Date"] = pd.to_datetime(df["Date"]).dt.date
+    raw_dates = df["Date"].astype(str).str.strip()
+    if raw_dates.apply(str.isdigit).all():
+        today = date.today()
+        df["Date"] = raw_dates.astype(int).apply(lambda d: date(today.year, today.month, d))
+    else:
+        df["Date"] = pd.to_datetime(raw_dates).dt.date
     _df.cache_clear()
     _df.__wrapped__ = lambda: df  # replace cached function
 


### PR DESCRIPTION
## Summary
- allow `store_csv` to accept numeric dates like `1,2,3`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685298f8330483299e0ef7e79a3a3511