### PR TITLE
Improve date handling and fallback

### DIFF
--- a/codes/data_source.py
+++ b/codes/data_source.py
@@ -8,7 +8,7 @@ import io
 from functools import lru_cache
 from datetime import date
 
-__all__ = ["store_csv", "get_scores"]
+__all__ = ["store_csv", "get_scores", "get_last_date"]
 
 @lru_cache(maxsize=1)
 def _df():
@@ -24,6 +24,14 @@ def store_csv(raw: bytes):
         df["Date"] = pd.to_datetime(raw_dates).dt.date
     _df.cache_clear()
     _df.__wrapped__ = lambda: df  # replace cached function
+
+def get_last_date() -> date:
+    """Return the last date present in the loaded CSV or today's date."""
+    try:
+        df = _df()
+    except RuntimeError:
+        return date.today()
+    return df["Date"].max()
 
 def get_scores(start: date, end: date) -> dict:
     try:


### PR DESCRIPTION
## Summary
- adjust data source to expose `get_last_date`
- consider latest CSV date in NLP utilities
- add friendlier fallback response if the language model isn't available

## Testing
- `python -m py_compile codes/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68529be7003c8329a81cb2c88b89a816